### PR TITLE
feat: support macos

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 source .venv/bin/activate
+export CPPFLAGS="-I$(brew --prefix)/include/onnxruntime -L${PWD}/espeak-ng/src/.libs"

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
 source .venv/bin/activate
-export CPPFLAGS="-I$(brew --prefix)/include/onnxruntime -L${PWD}/espeak-ng/src/.libs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "speech-service-api @ git+https://github.com/viam-labs/speech-service-api.git@v0.4.0",
     "piper-tts @ git+https://github.com/rhasspy/piper@e5cb84c#subdirectory=src/python_run ; platform_system == 'Linux'",
     "pyaudio>=0.2.14",
+    "piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@fix-python-install ; platform_system == 'Darwin'",
+    "piper-tts @ git+https://github.com/jmfrank63/piper@fix-python-install#subdirectory=src/python_run ; platform_system == 'Darwin'",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,8 @@ authors = [
 dependencies = [
     "viam-sdk>=0.15.0",
     "speech-service-api @ git+https://github.com/viam-labs/speech-service-api.git@v0.4.0",
-    "piper-tts @ git+https://github.com/rhasspy/piper@e5cb84c#subdirectory=src/python_run ; platform_system == 'Linux'",
-    "pyaudio>=0.2.14",
-    "piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@fix-python-install ; platform_system == 'Darwin'",
-    "piper-tts @ git+https://github.com/jmfrank63/piper@fix-python-install#subdirectory=src/python_run ; platform_system == 'Darwin'",
+    "piper-tts @ git+https://github.com/hipsterbrown/piper@master#subdirectory=src/python_run",
+    "pyaudio>=0.2.14"
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -8,6 +8,10 @@
 #   with-sources: false
 
 -e file:.
+coloredlogs==15.0.1
+    # via onnxruntime
+flatbuffers==24.3.7
+    # via onnxruntime
 googleapis-common-protos==1.63.0
     # via viam-sdk
 grpclib==0.4.6
@@ -16,19 +20,37 @@ h2==4.1.0
     # via grpclib
 hpack==4.0.0
     # via h2
+humanfriendly==10.0
+    # via coloredlogs
 hyperframe==6.0.1
     # via h2
+mpmath==1.3.0
+    # via sympy
 multidict==6.0.5
     # via grpclib
+numpy==1.26.4
+    # via onnxruntime
+onnxruntime==1.17.1
+    # via piper-tts
+packaging==24.0
+    # via onnxruntime
 pillow==10.2.0
     # via viam-sdk
+piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@71d7ede99e4ae1d5164fb8a0161cd522aa56c2ee
+    # via piper-tts
+    # via tts-piper
+piper-tts @ git+https://github.com/jmfrank63/piper@d0ef6402cd8f6d8cd046230e8d584e4850a07f5c#subdirectory=src/python_run
+    # via tts-piper
 protobuf==4.25.3
     # via googleapis-common-protos
+    # via onnxruntime
     # via viam-sdk
 pyaudio==0.2.14
     # via tts-piper
 speech-service-api @ git+https://github.com/viam-labs/speech-service-api.git@cd37fc3316afcda58d1b4b590812a1005f54efdb
     # via tts-piper
+sympy==1.12
+    # via onnxruntime
 typing-extensions==4.10.0
     # via viam-sdk
 viam-sdk==0.15.0

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -36,10 +36,9 @@ packaging==24.0
     # via onnxruntime
 pillow==10.2.0
     # via viam-sdk
-piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@71d7ede99e4ae1d5164fb8a0161cd522aa56c2ee
+piper-phonemize-cross==1.2.1
     # via piper-tts
-    # via tts-piper
-piper-tts @ git+https://github.com/jmfrank63/piper@d0ef6402cd8f6d8cd046230e8d584e4850a07f5c#subdirectory=src/python_run
+piper-tts @ git+https://github.com/hipsterbrown/piper@4ca58d0ce0c9b0771f0ca59a491dd2c7ba67d370#subdirectory=src/python_run
     # via tts-piper
 protobuf==4.25.3
     # via googleapis-common-protos

--- a/requirements.lock
+++ b/requirements.lock
@@ -8,6 +8,10 @@
 #   with-sources: false
 
 -e file:.
+coloredlogs==15.0.1
+    # via onnxruntime
+flatbuffers==24.3.7
+    # via onnxruntime
 googleapis-common-protos==1.63.0
     # via viam-sdk
 grpclib==0.4.6
@@ -16,19 +20,37 @@ h2==4.1.0
     # via grpclib
 hpack==4.0.0
     # via h2
+humanfriendly==10.0
+    # via coloredlogs
 hyperframe==6.0.1
     # via h2
+mpmath==1.3.0
+    # via sympy
 multidict==6.0.5
     # via grpclib
+numpy==1.26.4
+    # via onnxruntime
+onnxruntime==1.17.1
+    # via piper-tts
+packaging==24.0
+    # via onnxruntime
 pillow==10.2.0
     # via viam-sdk
+piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@71d7ede99e4ae1d5164fb8a0161cd522aa56c2ee
+    # via piper-tts
+    # via tts-piper
+piper-tts @ git+https://github.com/jmfrank63/piper@d0ef6402cd8f6d8cd046230e8d584e4850a07f5c#subdirectory=src/python_run
+    # via tts-piper
 protobuf==4.25.3
     # via googleapis-common-protos
+    # via onnxruntime
     # via viam-sdk
 pyaudio==0.2.14
     # via tts-piper
 speech-service-api @ git+https://github.com/viam-labs/speech-service-api.git@cd37fc3316afcda58d1b4b590812a1005f54efdb
     # via tts-piper
+sympy==1.12
+    # via onnxruntime
 typing-extensions==4.10.0
     # via viam-sdk
 viam-sdk==0.16.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -36,10 +36,9 @@ packaging==24.0
     # via onnxruntime
 pillow==10.2.0
     # via viam-sdk
-piper-phonemize @ git+https://github.com/jmfrank63/piper-phonemize@71d7ede99e4ae1d5164fb8a0161cd522aa56c2ee
+piper-phonemize-cross==1.2.1
     # via piper-tts
-    # via tts-piper
-piper-tts @ git+https://github.com/jmfrank63/piper@d0ef6402cd8f6d8cd046230e8d584e4850a07f5c#subdirectory=src/python_run
+piper-tts @ git+https://github.com/hipsterbrown/piper@4ca58d0ce0c9b0771f0ca59a491dd2c7ba67d370#subdirectory=src/python_run
     # via tts-piper
 protobuf==4.25.3
     # via googleapis-common-protos


### PR DESCRIPTION
In order to support using this module on MacOS machines, I forked the [piper-phonemize repo](https://github.com/HipsterBrown/piper-phonemize) in order to build cross-platform Python wheels for Linux (aarch64,x86_64) and MacOS (arm64,x86_64) and publish them to pypi.org as `piper-phonemize-cross`. Then I forked the [piper repo](https://github.com/HipsterBrown/piper) to updated the Python package's `requirements.txt` to use the `piper-phonemize-cross` dependency. Now this module only needs to depend on my `piper-tts` fork for any platform. 

I will eventually contribute my GitHub Actions automations for building the wheels back to the source project, so that this module can return to using that instead. 